### PR TITLE
Output compile errors in parseable 'emacs' format

### DIFF
--- a/builder/src/main/java/com/salesforce/bazel/jdt/toolchain/builder/JdtJavaBuilder.java
+++ b/builder/src/main/java/com/salesforce/bazel/jdt/toolchain/builder/JdtJavaBuilder.java
@@ -299,6 +299,7 @@ public class JdtJavaBuilder implements Closeable {
                     commandLineBuilder.append(optionsParser.getEclipsePreferencesFile().get()).append(" ");
                 }
             }
+            commandLineBuilder.append("-Xemacs ");
             // Compile using only the direct dependencies, if requested to. Otherwise use the full set of direct
             // and indirect dependencies.
             if (optionsParser.getUseDirectDepsOnly().orElse(false) && !optionsParser.getDirectJars().isEmpty()) {


### PR DESCRIPTION
The default error format for compile errors is difficult to parse, and not automatically picked up by IDEs.  This change makes the error format similar to the 'emacs' error format used by GCC and other compilers, so that in-IDE use can directly go to compile errors.