### PR TITLE
JSR308 style annotations require explicit @Target annotation

### DIFF
--- a/compiler/src/main/ecj/README.md
+++ b/compiler/src/main/ecj/README.md
@@ -5,6 +5,9 @@ We are using a patched version of ECJ 4.23 to incorporate fixes for:
 * Issue [844](https://github.com/eclipse-jdt/eclipse.jdt.core/issues/844) [PR 845](https://github.com/eclipse-jdt/eclipse.jdt.core/pull/845)
   (Bugzilla: [574111](https://bugs.eclipse.org/bugs/show_bug.cgi?id=574111) [Gerrit](https://git.eclipse.org/r/c/jdt/eclipse.jdt.core/+/181728))
 
+* Bugzilla [533199](https://bugs.eclipse.org/bugs/show_bug.cgi?id=533199)
+  - Reverting part of commit [Bug 552082 - Fix the applicability of a no-@target annotation type](https://github.com/eclipse-jdt/eclipse.jdt.core/commit/c07bc1c3061d9d8cee7ea123d74e67f097c7ad56)
+  - [JDK specification discussion](https://mail.openjdk.org/pipermail/compiler-dev/2019-September/013705.html)
 
 ## Issue with source/target and JDKs
 

--- a/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/ast/Annotation.java
+++ b/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/ast/Annotation.java
@@ -775,11 +775,12 @@ public abstract class Annotation extends Expression {
 		}
 		long metaTagBits = annotationBinding.getAnnotationTagBits(); // could be forward reference
 
-		if ((metaTagBits & (TagBits.AnnotationTargetMASK)) != 0) {
-			if ((metaTagBits & (TagBits.AnnotationForTypeParameter | TagBits.AnnotationForTypeUse)) == 0) {
-				return false;
-			}
-		} // else: no-@Target always applicable
+		if ((metaTagBits & (TagBits.AnnotationTargetMASK)) == 0) { // explicit target required for JSR308 style annotations.
+			return false;
+		}
+		if ((metaTagBits & (TagBits.AnnotationForTypeParameter | TagBits.AnnotationForTypeUse)) == 0) {
+			return false;
+		}
 
 		if ((metaTagBits & TagBits.AnnotationRetentionMASK) == 0)
 			return true; // by default the retention is CLASS
@@ -794,11 +795,13 @@ public abstract class Annotation extends Expression {
 		}
 		long metaTagBits = annotationBinding.getAnnotationTagBits();
 
-		if ((metaTagBits & (TagBits.AnnotationTargetMASK)) != 0) {
-			if ((metaTagBits & (TagBits.AnnotationForTypeParameter | TagBits.AnnotationForTypeUse)) == 0) {
-				return false;
-			}
-		} // else: no-@Target always applicable
+		if ((metaTagBits & (TagBits.AnnotationTargetMASK)) == 0) { // explicit target required for JSR308 style annotations.
+			return false;
+		}
+		if ((metaTagBits & (TagBits.AnnotationForTypeParameter | TagBits.AnnotationForTypeUse)) == 0) {
+			return false;
+		}
+
 		if ((metaTagBits & TagBits.AnnotationRetentionMASK) == 0)
 			return false; // by default the retention is CLASS
 


### PR DESCRIPTION
Reverting JDT Bug 552082-Fix the applicability of a no-@target annotation type updates, as the behavior is not compatible with JDK 11 and also with latest javac.

For jdt.core, refer to https://bugs.eclipse.org/bugs/show_bug.cgi?id=552082 for more details.

For javac, refer to https://bugs.openjdk.org/browse/JDK-8231435 and https://bugs.openjdk.org/browse/JDK-8231436 for more details.