### PR TITLE
Work around JDT absolute path issue.

### DIFF
--- a/.bazelproject
+++ b/.bazelproject
@@ -1,0 +1,13 @@
+# The project view file (.bazelproject) is used to import targets into the IDE.
+#
+# See: https://ij.bazel.build/docs/project-views.html
+#
+# This files provides a default experience for developers working with the project
+
+
+directories:
+  .
+
+derive_targets_from_directories: true
+
+java_language_level: 11

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bazel-*
 .project
 .settings/
 .classpath
+.eclipse
 
 # output folders
 bin/

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -70,6 +70,8 @@ jvm_maven_import_external(
     name = "rules_jdt_guava",
     artifact = "com.google.guava:guava:31.0.1-jre",
     artifact_sha256 = "d5be94d65e87bd219fb3193ad1517baa55a3b88fc91d21cf735826ab5af087b9",
+    srcjar_urls = [server + "/com/google/guava/guava/31.0.1-jre/guava-31.0.1-jre-sources.jar" for server in _DEFAULT_REPOSITORIES],
+    srcjar_sha256 = "fc0fb66f315f10b8713fc43354936d3649a8ad63f789d42fd7c3e55ecf72e092",
     licenses = ["notice"],
     server_urls = _DEFAULT_REPOSITORIES,
 )


### PR DESCRIPTION
This is a simple attempt to make paths in the output of the JDT compiler relative again. Somehow they end up becoming absolute, which breaks IDEs decided to rely on compiler output parsing for error reporting.

https://github.com/eclipse-jdt/eclipse.jdt.core/discussions/1061