### PR TITLE
Collect generates source as well as dependency information

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Once this is completed, add this to your `.bazelrc`:
 build --extra_toolchains=@bazel_jdt_java_toolchain//jdt:all
 ```
 
-By default the `jdt_java_toolchain` is using `local_jdk` for compilation. 
+By default the `jdt_java_toolchain` is using `local_jdk` for compilation.
 Please create your own `default_java_toolchain` if this doesn't work for your use case.
 
 Have a look at `jdt/BUILD` to see which JDKs are supported.
@@ -35,17 +35,18 @@ and point directly at the source of this repo for development and testing.
 
 Unfortunately this means additional steps are required for developers. This script can be
 used to facilitate the steps.
+
 ```
 #!/bin/bash
 
 bazel build :JdtJavaBuilder_deploy.jar
 cp -fv bazel-bin/JdtJavaBuilder_deploy.jar compiler/export/
 
-bazel build //compiler/third_party/turbine:turbine_direct_binary_deploy.jar 
+bazel build //compiler/third_party/turbine:turbine_direct_binary_deploy.jar
 cp -fv bazel-bin/compiler/third_party/turbine/turbine_direct_binary_deploy.jar compiler/tools/
 ```
 
-For your convinience, the `build-toolchain` script is provided in this repository.
+For your convenience, the `build-toolchain` script is provided in this repository.
 
 
 ## Debugging
@@ -85,8 +86,8 @@ ERROR: /Users/username/app/main/core/some-java-target/BUILD.bazel:4:13: Building
   /Users/username/tools/Darwin/jdk/bin/java -jar external/jdt_java_toolchain/builder/export/JdtJavaBuilder_deploy.jar @bazel-out/darwin-fastbuild/bin/some-java-target/libtarget-class.jar-0.params @bazel-out/darwin-fastbuild/bin/some-java-target/libtarget-class.jar-1.params)
 ```
 
-Either take the *SUBCOMMAND* or *ERROR* command. 
-You can ignore the `exec env` part. 
+Either take the *SUBCOMMAND* or *ERROR* command.
+You can ignore the `exec env` part.
 
 The interesting two steps are:
 
@@ -99,7 +100,7 @@ cd /private/var/tmp/_bazel_username/hash/execroot/core
 ```
 
 The first is the execution directory and the latter the command.
-You need to cd into the execution directory and then run the command yourself.
+You need to `cd` into the execution directory and then run the command yourself.
 But this time add the remote debug arguments (before `-jar`) as follows:
 
 ```
@@ -120,3 +121,4 @@ The VS Code Bazel Java extension should also work.
 ## Releasing
 
 See [RELEASING README](dist/README.md).
+

--- a/compiler/BUILD
+++ b/compiler/BUILD
@@ -35,6 +35,14 @@ java_library(
         "@rules_jdt_org_ow2_asm_asm_commons",
         "@rules_jdt_org_ow2_asm_asm_tree",
     ],
+    javacopts = [
+        "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.resources=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+    ],
     visibility = ["//:__subpackages__"],
 )
 

--- a/compiler/src/main/buildjar/com/google/devtools/build/buildjar/JavaLibraryBuildRequest.java
+++ b/compiler/src/main/buildjar/com/google/devtools/build/buildjar/JavaLibraryBuildRequest.java
@@ -176,7 +176,7 @@ public final class JavaLibraryBuildRequest {
     this.processingModule = processingBuilder.build();
 
     ImmutableList.Builder<BlazeJavaCompilerPlugin> pluginsBuilder =
-        ImmutableList.<BlazeJavaCompilerPlugin>builder();//.add(dependencyModule.getPlugin());
+        ImmutableList.<BlazeJavaCompilerPlugin>builder();//.add(dependencyModule.getPlugin()); // FIXME: need JDT accessibility rules to monitor strict deps
     processingModule.registerPlugin(pluginsBuilder);
     pluginsBuilder.addAll(extraPlugins);
     this.plugins = pluginsBuilder.build();

--- a/compiler/src/main/buildjar/com/google/devtools/build/buildjar/JavaLibraryBuildRequest.java
+++ b/compiler/src/main/buildjar/com/google/devtools/build/buildjar/JavaLibraryBuildRequest.java
@@ -176,7 +176,7 @@ public final class JavaLibraryBuildRequest {
     this.processingModule = processingBuilder.build();
 
     ImmutableList.Builder<BlazeJavaCompilerPlugin> pluginsBuilder =
-        ImmutableList.<BlazeJavaCompilerPlugin>builder();//.add(dependencyModule.getPlugin()); // FIXME: need JDT accessibility rules to monitor strict deps
+        ImmutableList.<BlazeJavaCompilerPlugin>builder().add(dependencyModule.getPlugin());
     processingModule.registerPlugin(pluginsBuilder);
     pluginsBuilder.addAll(extraPlugins);
     this.plugins = pluginsBuilder.build();

--- a/compiler/src/main/buildjar/com/google/devtools/build/buildjar/javac/BlazeJavacResult.java
+++ b/compiler/src/main/buildjar/com/google/devtools/build/buildjar/javac/BlazeJavacResult.java
@@ -14,10 +14,6 @@
 
 package com.google.devtools.build.buildjar.javac;
 
-import javax.annotation.Nullable;
-import javax.tools.JavaCompiler;
-
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.buildjar.javac.statistics.BlazeJavacStatistics;
 
@@ -35,42 +31,39 @@ public class BlazeJavacResult {
   private final Status status;
   private final ImmutableList<FormattedDiagnostic> diagnostics;
   private final String output;
-  private final JavaCompiler compiler;
   private final BlazeJavacStatistics statistics;
 
   public static BlazeJavacResult ok() {
-    return createFullResult(Status.OK, ImmutableList.of(), "", null, BlazeJavacStatistics.empty());
+    return createFullResult(Status.OK, ImmutableList.of(), "", BlazeJavacStatistics.empty());
   }
 
   public static BlazeJavacResult error(String message) {
     return createFullResult(
-        Status.ERROR, ImmutableList.of(), message, null, BlazeJavacStatistics.empty());
+        Status.ERROR, ImmutableList.of(), message, BlazeJavacStatistics.empty());
   }
 
   public static BlazeJavacResult cancelled(String message) {
     return createFullResult(
-        Status.CANCELLED, ImmutableList.of(), message, null, BlazeJavacStatistics.empty());
+        Status.CANCELLED, ImmutableList.of(), message, BlazeJavacStatistics.empty());
   }
 
   public static BlazeJavacResult fallback() {
     return createFullResult(
-        Status.REQUIRES_FALLBACK, ImmutableList.of(), "", null, BlazeJavacStatistics.empty());
+        Status.REQUIRES_FALLBACK, ImmutableList.of(), "", BlazeJavacStatistics.empty());
   }
 
   public BlazeJavacResult withStatistics(BlazeJavacStatistics statistics) {
-    return new BlazeJavacResult(status, diagnostics, output, compiler, statistics);
+    return new BlazeJavacResult(status, diagnostics, output, statistics);
   }
 
   private BlazeJavacResult(
       Status status,
       ImmutableList<FormattedDiagnostic> diagnostics,
       String output,
-      @Nullable JavaCompiler compiler,
       BlazeJavacStatistics statistics) {
     this.status = status;
     this.diagnostics = diagnostics;
     this.output = output;
-    this.compiler = compiler;
     this.statistics = statistics;
   }
 
@@ -78,9 +71,8 @@ public class BlazeJavacResult {
       Status status,
       ImmutableList<FormattedDiagnostic> diagnostics,
       String output,
-      JavaCompiler compiler,
       BlazeJavacStatistics statistics) {
-    return new BlazeJavacResult(status, diagnostics, output, compiler, statistics);
+    return new BlazeJavacResult(status, diagnostics, output, statistics);
   }
 
   public boolean isOk() {
@@ -101,10 +93,5 @@ public class BlazeJavacResult {
 
   public BlazeJavacStatistics statistics() {
     return statistics;
-  }
-
-  @VisibleForTesting
-  public JavaCompiler compiler() {
-    return compiler;
   }
 }

--- a/compiler/src/main/buildjar/com/google/devtools/build/buildjar/javac/plugins/dependency/DependencyModule.java
+++ b/compiler/src/main/buildjar/com/google/devtools/build/buildjar/javac/plugins/dependency/DependencyModule.java
@@ -117,7 +117,7 @@ public final class DependencyModule {
 
   /** Returns a plugin to be enabled in the compiler. */
   public BlazeJavaCompilerPlugin getPlugin() {
-	throw new IllegalStateException("not supported"); //return new StrictJavaDepsPlugin(this);
+	return new StrictJavaDepsPlugin(this);
   }
 
   /**

--- a/compiler/src/main/buildjar/com/google/devtools/build/buildjar/javac/plugins/dependency/ImplicitDependencyExtractor.java
+++ b/compiler/src/main/buildjar/com/google/devtools/build/buildjar/javac/plugins/dependency/ImplicitDependencyExtractor.java
@@ -1,0 +1,138 @@
+// Copyright 2014 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.buildjar.javac.plugins.dependency;
+
+import com.google.devtools.build.lib.view.proto.Deps;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.code.Symtab;
+import com.sun.tools.javac.util.Context;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import javax.lang.model.util.SimpleTypeVisitor7;
+import javax.tools.JavaFileObject;
+
+/**
+ * A lightweight mechanism for extracting compile-time dependencies from javac, by performing a scan
+ * of the symbol table after compilation finishes. It only includes dependencies from jar files,
+ * which can be interface jars or regular third_party jars, matching the compilation model of Blaze.
+ * Note that JDK8 may provide support for extracting per-class, finer-grained dependencies, and if
+ * that implementation has reasonable overhead it may be a future option.
+ */
+public class ImplicitDependencyExtractor {
+
+  /** Map collecting dependency information, used for the proto output */
+  private final Map<Path, Deps.Dependency> depsMap;
+
+  private final TypeVisitor typeVisitor = new TypeVisitor();
+  private final Set<Path> platformJars;
+
+  /**
+   * ImplicitDependencyExtractor does not guarantee any ordering of the reported dependencies.
+   * Clients should preserve the original classpath ordering if trying to minimize their classpaths
+   * using this information.
+   */
+  public ImplicitDependencyExtractor(Map<Path, Deps.Dependency> depsMap, Set<Path> platformJars) {
+    this.depsMap = depsMap;
+    this.platformJars = platformJars;
+  }
+
+  /**
+   * Collects the implicit dependencies of the given set of ClassSymbol roots. As we're interested
+   * in differentiating between symbols that were just resolved vs. symbols that were fully
+   * completed by the compiler, we start the analysis by finding all the implicit dependencies
+   * reachable from the given set of roots. For completeness, we then walk the symbol table
+   * associated with the given context and collect the jar files of the remaining class symbols
+   * found there.
+   *
+   * @param context compilation context
+   * @param roots root classes in the implicit dependency collection
+   */
+  public void accumulate(Context context, Set<ClassSymbol> roots) {
+    Symtab symtab = Symtab.instance(context);
+
+    // Collect transitive references for root types
+    for (ClassSymbol root : roots) {
+      root.type.accept(typeVisitor, null);
+    }
+
+    // Collect all other partially resolved types
+    for (ClassSymbol cs : symtab.getAllClasses()) {
+      // When recording we want to differentiate between jar references through completed symbols
+      // and incomplete symbols
+      boolean completed = cs.isCompleted();
+      if (cs.classfile != null) {
+        collectJarOf(cs.classfile, platformJars, completed);
+      } else if (cs.sourcefile != null) {
+        collectJarOf(cs.sourcefile, platformJars, completed);
+      }
+    }
+  }
+
+  /**
+   * Attempts to add the jar associated with the given JavaFileObject, if any, to the collection,
+   * filtering out jars on the compilation bootclasspath.
+   *
+   * @param reference JavaFileObject representing a class or source file
+   * @param platformJars classes on javac's bootclasspath
+   * @param completed whether the jar was referenced through a completed symbol
+   */
+  private void collectJarOf(JavaFileObject reference, Set<Path> platformJars, boolean completed) {
+
+    Path path = getJarPath(reference);
+    if (path == null) {
+      return;
+    }
+
+    // Filter out classes in rt.jar
+    if (platformJars.contains(path)) {
+      return;
+    }
+
+    Deps.Dependency currentDep = depsMap.get(path);
+
+    // If the dep hasn't been recorded we add it to the map
+    // If it's been recorded as INCOMPLETE but is now complete we upgrade the dependency
+    if (currentDep == null
+        || (completed && currentDep.getKind() == Deps.Dependency.Kind.INCOMPLETE)) {
+      depsMap.put(
+          path,
+          Deps.Dependency.newBuilder()
+              .setKind(completed ? Deps.Dependency.Kind.IMPLICIT : Deps.Dependency.Kind.INCOMPLETE)
+              .setPath(path.toString())
+              .build());
+    }
+  }
+
+  public static Path getJarPath(JavaFileObject file) {
+    if (file == null) {
+      return null;
+    }
+    try {
+      Field field = file.getClass().getDeclaredField("userJarPath");
+      field.setAccessible(true);
+      return (Path) field.get(file);
+    } catch (NoSuchFieldException e) {
+      return null;
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError(e.getMessage(), e);
+    }
+  }
+
+  private static class TypeVisitor extends SimpleTypeVisitor7<Void, Void> {
+    // TODO(bazel-team): Override the visitor methods we're interested in.
+  }
+}

--- a/compiler/src/main/buildjar/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
+++ b/compiler/src/main/buildjar/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
@@ -1,0 +1,524 @@
+// Copyright 2014 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.buildjar.javac.plugins.dependency;
+
+import javax.tools.JavaFileObject;
+
+import com.google.auto.value.AutoValue;
+import com.google.devtools.build.buildjar.javac.plugins.BlazeJavaCompilerPlugin;
+
+/**
+ * A plugin for BlazeJavaCompiler that checks for types referenced directly in the source, but
+ * included through transitive dependencies. To get this information, we hook into the type
+ * attribution phase of the BlazeJavaCompiler (thus the overhead is another tree scan with the
+ * classic visitor). The constructor takes a map from jar names to target names, only for the jars
+ * that come from transitive dependencies (Blaze computes this information).
+ */
+public final class StrictJavaDepsPlugin extends BlazeJavaCompilerPlugin {
+//  private static final Attributes.Name TARGET_LABEL = new Attributes.Name("Target-Label");
+//  private static final Attributes.Name INJECTING_RULE_KIND =
+//      new Attributes.Name("Injecting-Rule-Kind");
+
+//  private ImplicitDependencyExtractor implicitDependencyExtractor;
+//  private CheckingTreeScanner checkingTreeScanner;
+  private final DependencyModule dependencyModule;
+
+//  /** Marks seen compilation toplevels and their import sections */
+//  private final Set<JCTree.JCCompilationUnit> toplevels;
+//  /** Marks seen ASTs */
+//  private final Set<JCTree> trees;
+//  /** Computed missing dependencies */
+//  private final Set<JarOwner> missingTargets;
+//  /** Strict deps diagnostics. */
+//  private final List<SjdDiagnostic> diagnostics;
+//
+//  private PrintWriter errWriter;
+
+  @AutoValue
+  abstract static class SjdDiagnostic {
+    abstract int pos();
+
+    abstract String message();
+
+    abstract JavaFileObject source();
+
+    static SjdDiagnostic create(int pos, String message, JavaFileObject source) {
+      return new AutoValue_StrictJavaDepsPlugin_SjdDiagnostic(pos, message, source);
+    }
+  }
+
+  /**
+   * On top of javac, we keep Blaze-specific information in the form of two maps. Both map jars
+   * (exactly as they appear on the classpath) to target names, one is used for direct dependencies,
+   * the other for the transitive dependencies.
+   *
+   * <p>This enables the detection of dependency issues. For instance, when a type com.Foo is
+   * referenced in the source and it's coming from an indirect dependency, we emit a warning
+   * flagging that dependency. Also, we can check whether the direct dependencies were actually
+   * necessary, i.e. if their associated jars were used at all for looking up class definitions.
+   */
+  public StrictJavaDepsPlugin(DependencyModule dependencyModule) {
+    this.dependencyModule = dependencyModule;
+//    toplevels = new HashSet<>();
+//    trees = new HashSet<>();
+//    missingTargets = new HashSet<>();
+//    diagnostics = new ArrayList<>();
+  }
+
+  public DependencyModule getDependencyModule() {
+	return dependencyModule;
+  }
+
+//  @Override
+//  public void init(
+//      Context context,
+//      Log log,
+//      JavaCompiler compiler,
+//      BlazeJavacStatistics.Builder statisticsBuilder) {
+//    super.init(context, log, compiler, statisticsBuilder);
+//    errWriter = log.getWriter(WriterKind.ERROR);
+//    implicitDependencyExtractor =
+//        new ImplicitDependencyExtractor(
+//            dependencyModule.getImplicitDependenciesMap(),
+//            dependencyModule.getPlatformJars());
+//    checkingTreeScanner = context.get(CheckingTreeScanner.class);
+//    if (checkingTreeScanner == null) {
+//      Set<Path> platformJars = dependencyModule.getPlatformJars();
+//      checkingTreeScanner =
+//          new CheckingTreeScanner(dependencyModule, diagnostics, missingTargets, platformJars);
+//      context.put(CheckingTreeScanner.class, checkingTreeScanner);
+//    }
+//  }
+
+//  /**
+//   * We want to make another pass over the AST and "type-check" the usage of direct/transitive
+//   * dependencies after the type attribution phase.
+//   */
+//  @Override
+//  public void postAttribute(Env<AttrContext> env) {
+//    JavaFileObject previousSource = checkingTreeScanner.source;
+//    try {
+//      if (isAnnotationProcessorExempt(env.toplevel)) {
+//        return;
+//      }
+//      checkingTreeScanner.source =
+//          env.enclClass.sym.sourcefile != null
+//              ? env.enclClass.sym.sourcefile
+//              : env.toplevel.sourcefile;
+//      if (trees.add(env.tree)) {
+//        checkingTreeScanner.scan(env.tree);
+//      }
+//      if (toplevels.add(env.toplevel)) {
+//        checkingTreeScanner.scan(env.toplevel.getImports());
+//        checkingTreeScanner.scan(env.toplevel.getPackage());
+//        dependencyModule.addPackage(env.toplevel.packge);
+//      }
+//    } finally {
+//      checkingTreeScanner.source = previousSource;
+//    }
+//  }
+
+  @Override
+  public void finish() {
+//    implicitDependencyExtractor.accumulate(context, checkingTreeScanner.getSeenClasses());
+//
+//    for (SjdDiagnostic diagnostic : diagnostics) {
+//      JavaFileObject prev = log.useSource(diagnostic.source());
+//      try {
+//        switch (dependencyModule.getStrictJavaDeps()) {
+//          case ERROR:
+//            log.error(diagnostic.pos(), Errors.ProcMessager(diagnostic.message()));
+//            break;
+//          case WARN:
+//            log.warning(diagnostic.pos(), Warnings.ProcMessager(diagnostic.message()));
+//            break;
+//          case OFF: // continue below
+//        }
+//      } finally {
+//        log.useSource(prev);
+//      }
+//    }
+//
+//    if (!missingTargets.isEmpty()) {
+//      String canonicalizedLabel =
+//          dependencyModule.getTargetLabel() == null
+//              ? null
+//              // we don't use the target mapping for the target, just the missing deps
+//              : canonicalizeTarget(dependencyModule.getTargetLabel());
+//      Set<JarOwner> canonicalizedMissing =
+//          missingTargets
+//              .stream()
+//              .filter(owner -> owner.label().isPresent())
+//              .sorted(Comparator.comparing((JarOwner owner) -> owner.label().get()))
+//              // for dependencies that are missing we canonicalize and remap the target so we don't
+//              // suggest private build labels.
+//              .map(owner -> owner.withLabel(owner.label().map(label -> canonicalizeTarget(label))))
+//              .collect(toImmutableSet());
+//      if (dependencyModule.getStrictJavaDeps() != StrictJavaDeps.OFF) {
+//        errWriter.print(
+//            dependencyModule.getFixMessage().get(canonicalizedMissing, canonicalizedLabel));
+//        dependencyModule.setHasMissingTargets();
+//      }
+//    }
+  }
+
+//  /**
+//   * An AST visitor that implements our strict_java_deps checks. For now, it only emits warnings for
+//   * types loaded from jar files provided by transitive (indirect) dependencies. Each type is
+//   * considered only once, so at most one warning is generated for it.
+//   */
+//  private static class CheckingTreeScanner extends TreeScanner {
+//
+//    private final ImmutableSet<Path> directJars;
+//
+//    /** Strict deps diagnostics. */
+//    private final List<SjdDiagnostic> diagnostics;
+//
+//    /** Missing targets */
+//    private final Set<JarOwner> missingTargets;
+//
+//    /** Collect seen direct dependencies and their associated information */
+//    private final Map<Path, Deps.Dependency> directDependenciesMap;
+//
+//    /** We only emit one warning/error per class symbol */
+//    private final Set<ClassSymbol> seenClasses = new HashSet<>();
+//
+//    private final Set<JarOwner> seenTargets = new HashSet<>();
+//
+//    private final Set<Path> seenStrictDepsViolatingJars = new HashSet<>();
+//
+//    /** The set of jars on the compilation bootclasspath. */
+//    private final Set<Path> platformJars;
+//
+//    /** The current source, for diagnostics. */
+//    private JavaFileObject source = null;
+//
+//    public CheckingTreeScanner(
+//        DependencyModule dependencyModule,
+//        List<SjdDiagnostic> diagnostics,
+//        Set<JarOwner> missingTargets,
+//        Set<Path> platformJars) {
+//      this.directJars = dependencyModule.directJars();
+//      this.diagnostics = diagnostics;
+//      this.missingTargets = missingTargets;
+//      this.directDependenciesMap = dependencyModule.getExplicitDependenciesMap();
+//      this.platformJars = platformJars;
+//    }
+//
+//    Set<ClassSymbol> getSeenClasses() {
+//      return seenClasses;
+//    }
+//
+//    /** Checks an AST node denoting a class type against direct/transitive dependencies. */
+//    private void checkTypeLiteral(JCTree node, Symbol sym) {
+//      if (sym == null || sym.kind != Kinds.Kind.TYP) {
+//        return;
+//      }
+//      Path jarPath = getJarPath(sym.enclClass(), platformJars);
+//
+//      // If this type symbol comes from a class file loaded from a jar, check
+//      // whether that jar was a direct dependency and error out otherwise.
+//      if (jarPath != null && seenClasses.add(sym.enclClass())) {
+//        collectExplicitDependency(jarPath, node, sym);
+//      }
+//    }
+//
+//    /**
+//     * Marks the provided dependency as a direct/explicit dependency. Additionally, if
+//     * strict_java_deps is enabled, it emits a [strict] compiler warning/error.
+//     */
+//    private void collectExplicitDependency(Path jarPath, JCTree node, Symbol sym) {
+//      // Does it make sense to emit a warning/error for this pair of (type, owner)?
+//      // We want to emit only one error/warning per owner.
+//      if (!directJars.contains(jarPath) && seenStrictDepsViolatingJars.add(jarPath)) {
+//        // IO cost here is fine because we only hit this path for an explicit dependency
+//        // _not_ in the direct jars, i.e. an error
+//        JarOwner owner = readJarOwnerFromManifest(jarPath);
+//        if (seenTargets.add(owner)) {
+//          // owner is of the form "//label/of:rule <Aspect name>" where <Aspect name> is
+//          // optional.
+//          Optional<String> canonicalTargetName =
+//              owner.label().map(label -> canonicalizeTarget(label));
+//          missingTargets.add(owner);
+//          String toolInfo =
+//              owner.aspect().isPresent()
+//                  ? String.format(
+//                      "%s wrapped in %s", canonicalTargetName.get(), owner.aspect().get())
+//                  : canonicalTargetName.isPresent()
+//                      ? canonicalTargetName.get()
+//                      : owner.jar().toString();
+//          String used =
+//              sym.getSimpleName().contentEquals("package-info")
+//                  ? "package " + sym.getEnclosingElement()
+//                  : "type " + sym;
+//          String message =
+//              String.format(
+//                  "[strict] Using %s from an indirect dependency (TOOL_INFO: \"%s\").%s",
+//                  used, toolInfo, (owner.label().isPresent() ? " See command below **" : ""));
+//          diagnostics.add(SjdDiagnostic.create(node.pos, message, source));
+//        }
+//      }
+//
+//      if (!directDependenciesMap.containsKey(jarPath)) {
+//        // Also update the dependency proto
+//        Dependency dep =
+//            Dependency.newBuilder()
+//                // Path.toString uses the platform separator (`\` on Windows) which may not
+//                // match the format in params files (which currently always use `/`, see
+//                // bazelbuild/bazel#4108). JavaBuilder should always parse Path strings into
+//                // java.nio.file.Paths before comparing them.
+//                .setPath(jarPath.toString())
+//                .setKind(Dependency.Kind.EXPLICIT)
+//                .build();
+//        directDependenciesMap.put(jarPath, dep);
+//      }
+//    }
+//
+//    private static JarOwner readJarOwnerFromManifest(Path jarPath) {
+//      try (JarFile jarFile = new JarFile(jarPath.toFile())) {
+//        Manifest manifest = jarFile.getManifest();
+//        if (manifest == null) {
+//          return JarOwner.create(jarPath);
+//        }
+//        Attributes attributes = manifest.getMainAttributes();
+//        String label = (String) attributes.get(TARGET_LABEL);
+//        if (label == null) {
+//          return JarOwner.create(jarPath);
+//        }
+//        String injectingRuleKind = (String) attributes.get(INJECTING_RULE_KIND);
+//        return JarOwner.create(jarPath, label, Optional.ofNullable(injectingRuleKind));
+//      } catch (IOException e) {
+//        // This jar file pretty much has to exist, we just used it in the compiler. Throw unchecked.
+//        throw new UncheckedIOException(e);
+//      }
+//    }
+//
+//    @Override
+//    public void visitMethodDef(JCTree.JCMethodDecl method) {
+//      if ((method.mods.flags & Flags.GENERATEDCONSTR) != 0) {
+//        // If this is the constructor for an anonymous inner class, refrain from checking the
+//        // compiler-generated method signature. Don't skip scanning the method body though, there
+//        // might have been an anonymous initializer which still needs to be checked.
+//        scan(method.body);
+//      } else {
+//        super.visitMethodDef(method);
+//      }
+//    }
+//
+//    @Override
+//    public void visitVarDef(JCTree.JCVariableDecl variable) {
+//      scan(variable.mods);
+//      if (!declaredUsingVar(variable)) {
+//        scan(variable.vartype);
+//      }
+//      scan(variable.nameexpr);
+//      scan(variable.init);
+//    }
+//
+//    private static boolean declaredUsingVar(JCTree.JCVariableDecl variableTree) {
+//      return DECLARED_USING_VAR.test(variableTree);
+//    }
+//
+//    private static final Predicate<JCTree.JCVariableDecl> DECLARED_USING_VAR =
+//        getDeclaredUsingVar();
+//
+//    private static Predicate<JCTree.JCVariableDecl> getDeclaredUsingVar() {
+//      Method method;
+//      try {
+//        method = JCTree.JCVariableDecl.class.getMethod("declaredUsingVar");
+//      } catch (ReflectiveOperationException e) {
+//        // The method in JCVariableDecl is only available in stock JDK 17.
+//        // There are no good options for earlier versions, short of looking at the source code and
+//        // re-parsing the variable declaration, which would be complicated and expensive. For now,
+//        // continue to enforce SJD on var for JDK < 17.
+//        return variableTree -> false;
+//      }
+//      return variableTree -> {
+//        try {
+//          return (boolean) method.invoke(variableTree);
+//        } catch (ReflectiveOperationException e) {
+//          throw new LinkageError(e.getMessage(), e);
+//        }
+//      };
+//    }
+//
+//    /** Visits an identifier in the AST. We only care about type symbols. */
+//    @Override
+//    public void visitIdent(JCTree.JCIdent tree) {
+//      checkTypeLiteral(tree, tree.sym);
+//    }
+//
+//    /**
+//     * Visits a field selection in the AST. We care because in some cases types may appear fully
+//     * qualified and only inside a field selection (e.g., "com.foo.Bar.X", we want to catch the
+//     * reference to Bar).
+//     */
+//    @Override
+//    public void visitSelect(JCTree.JCFieldAccess tree) {
+//      scan(tree.selected);
+//      checkTypeLiteral(tree, tree.sym);
+//    }
+//
+//    @Override
+//    public void visitLambda(JCTree.JCLambda tree) {
+//      if (tree.paramKind != JCTree.JCLambda.ParameterKind.IMPLICIT) {
+//        // don't record type uses for implicitly typed lambda parameters
+//        scan(tree.params);
+//      }
+//      scan(tree.body);
+//    }
+//
+//    @Override
+//    public void visitPackageDef(JCTree.JCPackageDecl tree) {
+//      scan(tree.annotations);
+//      checkTypeLiteral(tree, tree.packge.package_info);
+//    }
+//  }
+//
+//  /**
+//   * Returns true if the compilation unit contains a single top-level class generated by an exempt
+//   * annotation processor (according to its {@link @Generated} annotation).
+//   *
+//   * <p>Annotation processors are expected to never generate more than one top level class, as
+//   * required by the style guide.
+//   */
+//  public boolean isAnnotationProcessorExempt(JCTree.JCCompilationUnit unit) {
+//    if (unit.getTypeDecls().size() != 1) {
+//      return false;
+//    }
+//    Symbol sym = TreeInfo.symbolFor(getOnlyElement(unit.getTypeDecls()));
+//    if (sym == null) {
+//      return false;
+//    }
+//    for (String value : getGeneratedBy(sym)) {
+//      if (dependencyModule.getExemptGenerators().contains(value)) {
+//        return true;
+//      }
+//    }
+//    return false;
+//  }
+//
+//  private static ImmutableSet<String> getGeneratedBy(Symbol symbol) {
+//    ImmutableSet.Builder<String> suppressions = ImmutableSet.builder();
+//    symbol
+//        .getRawAttributes()
+//        .stream()
+//        .filter(
+//            a -> {
+//              Name name = a.type.tsym.getQualifiedName();
+//              return name.contentEquals("javax.annotation.Generated")
+//                  || name.contentEquals("javax.annotation.processing.Generated");
+//            })
+//        .flatMap(
+//            a ->
+//                a.getElementValues()
+//                    .entrySet()
+//                    .stream()
+//                    .filter(e -> e.getKey().getSimpleName().contentEquals("value"))
+//                    .map(e -> e.getValue()))
+//        .forEachOrdered(
+//            a ->
+//                a.accept(
+//                    new SimpleAnnotationValueVisitor8<Void, Void>() {
+//                      @Override
+//                      public Void visitString(String s, Void aVoid) {
+//                        suppressions.add(s);
+//                        return super.visitString(s, aVoid);
+//                      }
+//
+//                      @Override
+//                      public Void visitArray(List<? extends AnnotationValue> vals, Void aVoid) {
+//                        vals.forEach(v -> v.accept(this, null));
+//                        return super.visitArray(vals, aVoid);
+//                      }
+//                    },
+//                    null));
+//    return suppressions.build();
+//  }
+//
+//  /** Returns the canonical version of the target name. Package private for testing. */
+//  static String canonicalizeTarget(String target) {
+//    int colonIndex = target.indexOf(':');
+//    if (colonIndex == -1) {
+//      // No ':' in target, nothing to do.
+//      return target;
+//    }
+//    int lastSlash = target.lastIndexOf('/', colonIndex);
+//    if (lastSlash == -1) {
+//      // No '/' or target is actually a filename in label format, return unmodified.
+//      return target;
+//    }
+//    String packageName = target.substring(lastSlash + 1, colonIndex);
+//    String suffix = target.substring(colonIndex + 1);
+//    if (packageName.equals(suffix)) {
+//      // target ends in "/something:something", canonicalize.
+//      return target.substring(0, colonIndex);
+//    }
+//    return target;
+//  }
+//
+//  /**
+//   * Returns the name of the jar file from which the given class symbol was loaded, if available,
+//   * and null otherwise. Implicitly filters out jars from the compilation bootclasspath.
+//   *
+//   * @param platformJars jars on javac's bootclasspath
+//   */
+//  public static Path getJarPath(ClassSymbol classSymbol, Set<Path> platformJars) {
+//    if (classSymbol == null) {
+//      return null;
+//    }
+//
+//    // Ignore symbols that appear in the sourcepath:
+//    if (haveSourceForSymbol(classSymbol)) {
+//      return null;
+//    }
+//
+//    JavaFileObject classfile = classSymbol.classfile;
+//
+//    Path path = ImplicitDependencyExtractor.getJarPath(classfile);
+//    if (path == null) {
+//      return null;
+//    }
+//
+//    // Filter out classes on bootclasspath
+//    if (platformJars.contains(path)) {
+//      return null;
+//    }
+//
+//    return path;
+//  }
+//
+//  /** Returns true if the given classSymbol corresponds to one of the sources being compiled. */
+//  private static boolean haveSourceForSymbol(ClassSymbol classSymbol) {
+//    if (classSymbol.sourcefile == null) {
+//      return false;
+//    }
+//
+//    try {
+//      // The classreader uses metadata to populate the symbol's sourcefile with a fake file object.
+//      // Call getLastModified() to check if it's a real file:
+//      classSymbol.sourcefile.getLastModified();
+//    } catch (UnsupportedOperationException e) {
+//      return false;
+//    }
+//
+//    return true;
+//  }
+//
+//  @Override
+//  public boolean runOnAttributionErrors() {
+//    return true;
+//  }
+}

--- a/compiler/src/main/buildjar/com/google/devtools/build/buildjar/javac/plugins/processing/AnnotationProcessingPlugin.java
+++ b/compiler/src/main/buildjar/com/google/devtools/build/buildjar/javac/plugins/processing/AnnotationProcessingPlugin.java
@@ -26,6 +26,10 @@ public class AnnotationProcessingPlugin extends BlazeJavaCompilerPlugin {
     this.processingModule = processingModule;
   }
 
+  public AnnotationProcessingModule getProcessingModule() {
+	return processingModule;
+  }
+
 //  @Override
 //  public void postAttribute(Env<AttrContext> env) {
 //    if (toplevels.add(env.toplevel)) {

--- a/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathJar.java
+++ b/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathJar.java
@@ -30,16 +30,16 @@ import java.util.zip.ZipFile;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
+import org.eclipse.jdt.internal.compiler.batch.FileSystem.ClasspathAnswer;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.classfmt.ExternalAnnotationDecorator;
 import org.eclipse.jdt.internal.compiler.classfmt.ExternalAnnotationProvider;
 import org.eclipse.jdt.internal.compiler.env.AccessRuleSet;
-import org.eclipse.jdt.internal.compiler.env.IModule;
-import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
-import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
+import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding.ExternalAnnotationStatus;
+import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.util.ManifestAnalyzer;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import org.eclipse.jdt.internal.compiler.util.Util;
@@ -108,11 +108,11 @@ public List<Classpath> fetchLinkedJars(FileSystem.ClasspathSectionProblemReporte
 	}
 }
 @Override
-public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName) {
+public ClasspathAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName) {
 	return findClass(typeName, qualifiedPackageName, moduleName, qualifiedBinaryFileName, false);
 }
 @Override
-public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly) {
+public ClasspathAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly) {
 	if (!isPackage(qualifiedPackageName, moduleName))
 		return null; // most common case
 
@@ -147,7 +147,7 @@ public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageN
 				// location is configured for external annotations, but no .eea found, decorate in order to answer NO_EEA_FILE:
 				reader = new ExternalAnnotationDecorator(reader, null);
 			}
-			return new NameEnvironmentAnswer(reader, fetchAccessRestriction(qualifiedBinaryFileName), modName);
+			return new ClasspathAnswer(reader, fetchAccessRestriction(qualifiedBinaryFileName), modName, this);
 		}
 	} catch (ClassFormatException | IOException e) {
 		// treat as if class file is missing

--- a/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247.java
+++ b/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247.java
@@ -32,12 +32,12 @@ import java.util.Set;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
+import org.eclipse.jdt.internal.compiler.batch.FileSystem.ClasspathAnswer;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.env.AccessRuleSet;
 import org.eclipse.jdt.internal.compiler.env.IModule;
-import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.util.CtSym;
 import org.eclipse.jdt.internal.compiler.util.JRTUtil;
@@ -67,11 +67,11 @@ public class ClasspathJep247 extends ClasspathJrt {
 		 return null;
 	}
 	@Override
-	public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName) {
+	public ClasspathAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName) {
 		return findClass(typeName, qualifiedPackageName, moduleName, qualifiedBinaryFileName, false);
 	}
 	@Override
-	public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly) {
+	public ClasspathAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly) {
 		if (!isPackage(qualifiedPackageName, moduleName))
 			return null; // most common case
 
@@ -95,7 +95,7 @@ public class ClasspathJep247 extends ClasspathJrt {
 			if (content != null) {
 				reader = new ClassFileReader(content, qualifiedBinaryFileName.toCharArray());
 				char[] modName = moduleName != null ? moduleName.toCharArray() : null;
-				return new NameEnvironmentAnswer(reader, fetchAccessRestriction(qualifiedBinaryFileName), modName);
+				return new ClasspathAnswer(reader, fetchAccessRestriction(qualifiedBinaryFileName), modName, this);
 			}
 		} catch (ClassFormatException | IOException e) {
 			// continue

--- a/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247Jdk12.java
+++ b/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247Jdk12.java
@@ -32,12 +32,12 @@ import java.util.function.Function;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
+import org.eclipse.jdt.internal.compiler.batch.FileSystem.ClasspathAnswer;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.env.AccessRuleSet;
 import org.eclipse.jdt.internal.compiler.env.IModule;
-import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.util.CtSym;
 import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 import org.eclipse.jdt.internal.compiler.util.Util;
@@ -55,11 +55,11 @@ public class ClasspathJep247Jdk12 extends ClasspathJep247 {
 		 return null;
 	}
 	@Override
-	public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName) {
+	public ClasspathAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName) {
 		return findClass(typeName, qualifiedPackageName, moduleName, qualifiedBinaryFileName, false);
 	}
 	@Override
-	public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly) {
+	public ClasspathAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly) {
 		if (!isPackage(qualifiedPackageName, moduleName))
 			return null; // most common case
 
@@ -98,7 +98,7 @@ public class ClasspathJep247Jdk12 extends ClasspathJep247 {
 			if (content != null) {
 				reader = new ClassFileReader(content, qualifiedBinaryFileName.toCharArray());
 				char[] modName = moduleName != null ? moduleName.toCharArray() : foundModName;
-				return new NameEnvironmentAnswer(reader, fetchAccessRestriction(qualifiedBinaryFileName), modName);
+				return new ClasspathAnswer(reader, fetchAccessRestriction(qualifiedBinaryFileName), modName, this);
 			}
 		} catch (ClassFormatException | IOException e) {
 			// continue
@@ -166,7 +166,7 @@ public class ClasspathJep247Jdk12 extends ClasspathJep247 {
 					if (!rel.contains(this.releaseInHex)) {
 						continue;
 					}
-					Files.walkFileTree(subdir, Collections.EMPTY_SET, 2, new FileVisitor<java.nio.file.Path>() {
+					Files.walkFileTree(subdir, Collections.emptySet(), 2, new FileVisitor<java.nio.file.Path>() {
 
 						@Override
 						public FileVisitResult preVisitDirectory(java.nio.file.Path dir, BasicFileAttributes attrs)

--- a/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathJmod.java
+++ b/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathJmod.java
@@ -23,14 +23,14 @@ import java.util.zip.ZipEntry;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
+import org.eclipse.jdt.internal.compiler.batch.FileSystem.ClasspathAnswer;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.classfmt.ExternalAnnotationDecorator;
 import org.eclipse.jdt.internal.compiler.classfmt.ExternalAnnotationProvider;
 import org.eclipse.jdt.internal.compiler.env.AccessRuleSet;
-import org.eclipse.jdt.internal.compiler.env.IModule;
-import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
+import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding.ExternalAnnotationStatus;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import org.eclipse.jdt.internal.compiler.util.Util;
@@ -51,7 +51,7 @@ public List<Classpath> fetchLinkedJars(FileSystem.ClasspathSectionProblemReporte
 	return null;
 }
 @Override
-public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly) {
+public ClasspathAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly) {
 	if (!isPackage(qualifiedPackageName, moduleName))
 		return null; // most common case
 
@@ -87,7 +87,7 @@ public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageN
 				// location is configured for external annotations, but no .eea found, decorate in order to answer NO_EEA_FILE:
 				reader = new ExternalAnnotationDecorator(reader, null);
 			}
-			return new NameEnvironmentAnswer(reader, fetchAccessRestriction(qualifiedBinaryFileName), modName);
+			return new ClasspathAnswer(reader, fetchAccessRestriction(qualifiedBinaryFileName), modName, this);
 		}
 	} catch (ClassFormatException | IOException e) {
 		// treat as if class file is missing

--- a/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathJrt.java
+++ b/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathJrt.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.internal.compiler.batch;
 
 import java.io.File;
 import java.io.IOException;
-
 import java.nio.file.FileVisitResult;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -31,15 +30,15 @@ import java.util.function.Function;
 import java.util.zip.ZipFile;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
+import org.eclipse.jdt.internal.compiler.batch.FileSystem.ClasspathAnswer;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.classfmt.ExternalAnnotationDecorator;
 import org.eclipse.jdt.internal.compiler.env.AccessRuleSet;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.compiler.env.IModule;
-import org.eclipse.jdt.internal.compiler.env.IMultiModuleEntry;
-import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.env.IModule.IPackageExport;
+import org.eclipse.jdt.internal.compiler.env.IMultiModuleEntry;
 import org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding.ExternalAnnotationStatus;
 import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
@@ -76,11 +75,11 @@ public class ClasspathJrt extends ClasspathLocation implements IMultiModuleEntry
 		return JRTUtil.hasCompilationUnit(this.file, qualifiedPackageName, moduleName);
 	}
 	@Override
-	public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName) {
+	public ClasspathAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName) {
 		return findClass(typeName, qualifiedPackageName, moduleName, qualifiedBinaryFileName, false);
 	}
 	@Override
-	public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly) {
+	public ClasspathAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly) {
 		if (!isPackage(qualifiedPackageName, moduleName))
 			return null; // most common case
 
@@ -111,7 +110,7 @@ public class ClasspathJrt extends ClasspathLocation implements IMultiModuleEntry
 				char[] answerModuleName = reader.getModule();
 				if (answerModuleName == null && moduleName != null)
 					answerModuleName = moduleName.toCharArray();
-				return new NameEnvironmentAnswer(reader, fetchAccessRestriction(qualifiedBinaryFileName), answerModuleName);
+				return new ClasspathAnswer(reader, fetchAccessRestriction(qualifiedBinaryFileName), answerModuleName, this);
 			}
 		} catch (ClassFormatException | IOException e) {
 			// treat as if class file is missing

--- a/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathJsr199.java
+++ b/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathJsr199.java
@@ -31,10 +31,10 @@ import javax.tools.JavaFileObject;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
+import org.eclipse.jdt.internal.compiler.batch.FileSystem.ClasspathAnswer;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.env.IModule;
-import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class ClasspathJsr199 extends ClasspathLocation {
@@ -77,7 +77,7 @@ public class ClasspathJsr199 extends ClasspathLocation {
 	}
 
 	@Override
-	public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName,
+	public ClasspathAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName,
 			String aQualifiedBinaryFileName, boolean asBinaryOnly) {
 		if (this.jrt != null) {
 			return this.jrt.findClass(typeName, qualifiedPackageName, moduleName, aQualifiedBinaryFileName, asBinaryOnly);
@@ -102,7 +102,7 @@ public class ClasspathJsr199 extends ClasspathLocation {
 			try (InputStream inputStream = jfo.openInputStream()) {
 				ClassFileReader reader = ClassFileReader.read(inputStream, qualifiedBinaryFileName);
 				if (reader != null) {
-					return new NameEnvironmentAnswer(reader, fetchAccessRestriction(qualifiedBinaryFileName));
+					return new ClasspathAnswer(reader, fetchAccessRestriction(qualifiedBinaryFileName), this);
 				}
 			}
 		} catch (ClassFormatException e) {
@@ -272,7 +272,7 @@ public class ClasspathJsr199 extends ClasspathLocation {
 	}
 
 	@Override
-	public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName,
+	public ClasspathAnswer findClass(char[] typeName, String qualifiedPackageName,
 			String moduleName, String qualifiedBinaryFileName) {
 		//
 		return findClass(typeName, qualifiedPackageName, moduleName, qualifiedBinaryFileName, false);

--- a/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathMultiReleaseJar.java
+++ b/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathMultiReleaseJar.java
@@ -16,12 +16,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.zip.ZipEntry;
 
+import org.eclipse.jdt.internal.compiler.batch.FileSystem.ClasspathAnswer;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.classfmt.ExternalAnnotationDecorator;
 import org.eclipse.jdt.internal.compiler.env.AccessRuleSet;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
-import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding.ExternalAnnotationStatus;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import org.eclipse.jdt.internal.compiler.util.Util;
@@ -111,7 +111,7 @@ public class ClasspathMultiReleaseJar extends ClasspathJar {
 		return singletonModuleNameIf(this.packageCache.contains(qualifiedPackageName));
 	}
 	@Override
-	public NameEnvironmentAnswer findClass(char[] binaryFileName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly) {
+	public ClasspathAnswer findClass(char[] binaryFileName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly) {
 		if (!isPackage(qualifiedPackageName, moduleName)) return null; // most common case
 		if (this.releasePath != null) {
 			try {
@@ -152,10 +152,11 @@ public class ClasspathMultiReleaseJar extends ClasspathJar {
 							reader = new ExternalAnnotationDecorator(reader, null);
 						}
 					if (this.accessRuleSet == null)
-						return new NameEnvironmentAnswer(reader, null, modName);
-					return new NameEnvironmentAnswer(reader,
+						return new ClasspathAnswer(reader, null, modName, this);
+					return new ClasspathAnswer(reader,
 							this.accessRuleSet.getViolatedRestriction(fileNameWithoutExtension.toCharArray()),
-							modName);
+							modName,
+							this);
 				}
 			} catch (IOException | ClassFormatException e) {
 				// treat as if class file is missing

--- a/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathSourceJar.java
+++ b/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/ClasspathSourceJar.java
@@ -14,12 +14,12 @@
 package org.eclipse.jdt.internal.compiler.batch;
 
 import java.io.File;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.zip.ZipEntry;
 
+import org.eclipse.jdt.internal.compiler.batch.FileSystem.ClasspathAnswer;
 import org.eclipse.jdt.internal.compiler.env.AccessRuleSet;
-import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.util.Util;
 
 public class ClasspathSourceJar extends ClasspathJar {
@@ -33,7 +33,7 @@ public class ClasspathSourceJar extends ClasspathJar {
 	}
 
 	@Override
-	public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly) {
+	public ClasspathAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly) {
 		if (!isPackage(qualifiedPackageName, moduleName))
 			return null; // most common case
 
@@ -55,9 +55,10 @@ public class ClasspathSourceJar extends ClasspathJar {
 					this.encoding,
 					this.destinationPath);
 				compilationUnit.module = this.module == null ? null : this.module.name();
-				return new NameEnvironmentAnswer(
+				return new ClasspathAnswer(
 					compilationUnit,
-					fetchAccessRestriction(qualifiedBinaryFileName));
+					fetchAccessRestriction(qualifiedBinaryFileName),
+					this);
 			} catch (IOException e) {
 				// treat as if source file is missing
 			}

--- a/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
+++ b/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
@@ -39,19 +39,24 @@ import org.eclipse.jdt.internal.compiler.CompilationResult;
 import org.eclipse.jdt.internal.compiler.DefaultErrorHandlingPolicies;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
 import org.eclipse.jdt.internal.compiler.classfmt.ExternalAnnotationDecorator;
+import org.eclipse.jdt.internal.compiler.env.AccessRestriction;
 import org.eclipse.jdt.internal.compiler.env.AccessRuleSet;
-import org.eclipse.jdt.internal.compiler.env.IModulePathEntry;
+import org.eclipse.jdt.internal.compiler.env.IBinaryType;
+import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jdt.internal.compiler.env.IModuleAwareNameEnvironment;
-import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
-import org.eclipse.jdt.internal.compiler.lookup.ModuleBinding;
-import org.eclipse.jdt.internal.compiler.parser.Parser;
-import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
-import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
+import org.eclipse.jdt.internal.compiler.env.IModulePathEntry;
+import org.eclipse.jdt.internal.compiler.env.ISourceType;
 import org.eclipse.jdt.internal.compiler.env.IUpdatableModule;
 import org.eclipse.jdt.internal.compiler.env.IUpdatableModule.UpdateKind;
 import org.eclipse.jdt.internal.compiler.env.IUpdatableModule.UpdatesByKind;
+import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.compiler.lookup.ModuleBinding;
+import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
+import org.eclipse.jdt.internal.compiler.parser.Parser;
+import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
+import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
 import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import org.eclipse.jdt.internal.compiler.util.Util;
@@ -60,6 +65,43 @@ public class FileSystem implements IModuleAwareNameEnvironment, SuffixConstants 
 
 	// Keep the type as ArrayList and not List as there are clients that are already written to expect ArrayList.
 	public static ArrayList<FileSystem.Classpath> EMPTY_CLASSPATH = new ArrayList<>();
+
+	public static class ClasspathAnswer extends NameEnvironmentAnswer {
+
+		public final Classpath source;
+
+		public ClasspathAnswer(IBinaryType binaryType, AccessRestriction accessRestriction, char[] module, Classpath source) {
+			super(binaryType, accessRestriction, module);
+			this.source = source;
+		}
+
+		public ClasspathAnswer(IBinaryType binaryType, AccessRestriction accessRestriction, Classpath source) {
+			super(binaryType, accessRestriction);
+			this.source = source;
+		}
+
+		public ClasspathAnswer(ICompilationUnit compilationUnit, AccessRestriction accessRestriction, char[] module, Classpath source) {
+			super(compilationUnit, accessRestriction, module);
+			this.source = source;
+		}
+
+		public ClasspathAnswer(ICompilationUnit compilationUnit, AccessRestriction accessRestriction, Classpath source) {
+			super(compilationUnit, accessRestriction);
+			this.source = source;
+		}
+
+		public ClasspathAnswer(ISourceType[] sourceTypes, AccessRestriction accessRestriction,
+				String externalAnnotationPath, char[] module, Classpath source) {
+			super(sourceTypes, accessRestriction, externalAnnotationPath, module);
+			this.source = source;
+		}
+
+		public ClasspathAnswer(ReferenceBinding binding, ModuleBinding module, Classpath source) {
+			super(binding, module);
+			this.source = source;
+		}
+
+	}
 
 	/**
 	 * A <code>Classpath</code>, even though an IModuleLocation, can represent a plain
@@ -70,8 +112,8 @@ public class FileSystem implements IModuleAwareNameEnvironment, SuffixConstants 
 	 */
 	public interface Classpath extends IModulePathEntry {
 		char[][][] findTypeNames(String qualifiedPackageName, String moduleName);
-		NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName);
-		NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly);
+		ClasspathAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName);
+		ClasspathAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly);
 		boolean isPackage(String qualifiedPackageName, /*@Nullable*/String moduleName);
 		default boolean hasModule() { return getModule() != null; }
 		default boolean hasCUDeclaringPackage(String qualifiedPackageName, Function<CompilationUnit, String> pkgNameExtractor) {
@@ -168,6 +210,8 @@ public class FileSystem implements IModuleAwareNameEnvironment, SuffixConstants 
 	protected boolean annotationsFromClasspath; // should annotation files be read from the classpath (vs. explicit separate path)?
 	private static HashMap<File, Classpath> JRT_CLASSPATH_CACHE = null;
 	protected Map<String,Classpath> moduleLocations = new HashMap<>();
+
+	public Consumer<ClasspathAnswer> nameEnvironmentListener = null; // listener for findType* methods
 
 	/** Tasks resulting from --add-reads or --add-exports command line options. */
 	Map<String,UpdatesByKind> moduleUpdates = new HashMap<>();
@@ -416,8 +460,8 @@ private static String convertPathSeparators(String path) {
 		? path.replace('\\', '/')
 		 : path.replace('/', '\\');
 }
-private NameEnvironmentAnswer findClass(String qualifiedTypeName, char[] typeName, boolean asBinaryOnly, /*NonNull*/char[] moduleName) {
-	NameEnvironmentAnswer answer = internalFindClass(qualifiedTypeName, typeName, asBinaryOnly, moduleName);
+private ClasspathAnswer findClass(String qualifiedTypeName, char[] typeName, boolean asBinaryOnly, /*NonNull*/char[] moduleName) {
+	ClasspathAnswer answer = internalFindClass(qualifiedTypeName, typeName, asBinaryOnly, moduleName);
 	if (this.annotationsFromClasspath && answer != null && answer.getBinaryType() instanceof ClassFileReader) {
 		for (int i = 0, length = this.classpaths.length; i < length; i++) {
 			Classpath classpathEntry = this.classpaths[i];
@@ -432,6 +476,7 @@ private NameEnvironmentAnswer findClass(String qualifiedTypeName, char[] typeNam
 					}
 					answer.setBinaryType(ExternalAnnotationDecorator.create(answer.getBinaryType(), classpathEntry.getPath(),
 							qualifiedTypeName, zip));
+					if (nameEnvironmentListener != null) nameEnvironmentListener.accept(answer);
 					return answer;
 				} catch (IOException e) {
 					// ignore broken entry, keep searching
@@ -446,9 +491,10 @@ private NameEnvironmentAnswer findClass(String qualifiedTypeName, char[] typeNam
 		// globally configured (annotationsFromClasspath), but no .eea found, decorate in order to answer NO_EEA_FILE:
 		answer.setBinaryType(new ExternalAnnotationDecorator(answer.getBinaryType(), null));
 	}
+	if (nameEnvironmentListener != null && answer != null) nameEnvironmentListener.accept(answer);
 	return answer;
 }
-private NameEnvironmentAnswer internalFindClass(String qualifiedTypeName, char[] typeName, boolean asBinaryOnly, /*NonNull*/char[] moduleName) {
+private ClasspathAnswer internalFindClass(String qualifiedTypeName, char[] typeName, boolean asBinaryOnly, /*NonNull*/char[] moduleName) {
 	if (this.knownFileNames.contains(qualifiedTypeName)) return null; // looking for a file which we know was provided at the beginning of the compilation
 
 	String qualifiedBinaryFileName = qualifiedTypeName + SUFFIX_STRING_class;
@@ -470,12 +516,12 @@ private NameEnvironmentAnswer internalFindClass(String qualifiedTypeName, char[]
 		return null;
 	}
 	String qp2 = File.separatorChar == '/' ? qualifiedPackageName : qualifiedPackageName.replace('/', File.separatorChar);
-	NameEnvironmentAnswer suggestedAnswer = null;
+	ClasspathAnswer suggestedAnswer = null;
 	if (qualifiedPackageName == qp2) {
 		for (int i = 0, length = this.classpaths.length; i < length; i++) {
 			if (!strategy.matches(this.classpaths[i], Classpath::hasModule))
 				continue;
-			NameEnvironmentAnswer answer = this.classpaths[i].findClass(typeName, qualifiedPackageName, null, qualifiedBinaryFileName, asBinaryOnly);
+			ClasspathAnswer answer = this.classpaths[i].findClass(typeName, qualifiedPackageName, null, qualifiedBinaryFileName, asBinaryOnly);
 			if (answer != null) {
 				if (answer.moduleName() != null && !this.moduleLocations.containsKey(String.valueOf(answer.moduleName())))
 					continue; // type belongs to an unobservable module
@@ -493,7 +539,7 @@ private NameEnvironmentAnswer internalFindClass(String qualifiedTypeName, char[]
 			Classpath p = this.classpaths[i];
 			if (!strategy.matches(p, Classpath::hasModule))
 				continue;
-			NameEnvironmentAnswer answer = !(p instanceof ClasspathDirectory)
+			ClasspathAnswer answer = !(p instanceof ClasspathDirectory)
 				? p.findClass(typeName, qualifiedPackageName, null, qualifiedBinaryFileName, asBinaryOnly)
 				: p.findClass(typeName, qp2, null, qb2, asBinaryOnly);
 			if (answer != null) {
@@ -512,7 +558,7 @@ private NameEnvironmentAnswer internalFindClass(String qualifiedTypeName, char[]
 }
 
 @Override
-public NameEnvironmentAnswer findType(char[][] compoundName, char[] moduleName) {
+public ClasspathAnswer findType(char[][] compoundName, char[] moduleName) {
 	if (compoundName != null)
 		return findClass(
 			new String(CharOperation.concatWith(compoundName, '/')),
@@ -565,7 +611,7 @@ public char[][][] findTypeNames(char[][] packageName) {
 }
 
 @Override
-public NameEnvironmentAnswer findType(char[] typeName, char[][] packageName, char[] moduleName) {
+public ClasspathAnswer findType(char[] typeName, char[][] packageName, char[] moduleName) {
 	if (typeName != null)
 		return findClass(
 			new String(CharOperation.concatWith(packageName, typeName, '/')),

--- a/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/Main.java
+++ b/compiler/src/main/ecj/org/eclipse/jdt/internal/compiler/batch/Main.java
@@ -3870,7 +3870,7 @@ protected void handleWarningToken(String token, boolean isEnabling) {
 protected void handleErrorToken(String token, boolean isEnabling) {
 	handleErrorOrWarningToken(token, isEnabling, ProblemSeverities.Error);
 }
-private void setSeverity(String compilerOptions, int severity, boolean isEnabling) {
+protected void setSeverity(String compilerOptions, int severity, boolean isEnabling) {
 	if (isEnabling) {
 		switch(severity) {
 			case ProblemSeverities.Error :


### PR DESCRIPTION
Switch to using the JDT Batch compiler directly, dropping the use of the tool interface.
Add support for computing list of generated sources during annotation processing.
Add support for computing list of used dependencies.
Add support for configuring access rules based on strict dependency checking.